### PR TITLE
docs: rewrite all .md files for OSIF v2.0.0 enterprise release

### DIFF
--- a/.agent/RELEASE_NOTES_v2.0.0.md
+++ b/.agent/RELEASE_NOTES_v2.0.0.md
@@ -1,166 +1,216 @@
-# OSIF v2.0.0 - Web Interface & Enhanced Features 🎉
+# OSIF v2.0.0 — Enterprise OSINT Web Workspace
 
-We're excited to announce OSIF v2.0.0, a major release that transforms OSIF into a dual-interface OSINT platform with a brand new web-based graph visualization system!
-
-## 🌟 Highlights
-
-### 🌐 Web Graph Visualization
-The biggest addition in v2.0.0 is the **interactive web interface** featuring Maltego-style graph visualization:
-
-- **Visual Investigation**: Interactive node-edge graph for exploring relationships
-- **Real-time Updates**: Watch your investigation graph grow as entities are discovered
-- **Multiple Entry Points**: Investigate domains, IPs, emails, and Bitcoin addresses
-- **Smart Interactions**: Click nodes for details, double-click to investigate further
-- **Export Capabilities**: Save your investigation graphs as JSON
-
-![Web Graph Visualization](screenshots/web_graph.png)
-
-### 🛡️ IP Reputation Intelligence
-New **AbuseIPDB integration** provides comprehensive IP threat intelligence:
-
-- Abuse confidence scoring (0-100%)
-- Threat level classification (Low/Medium/High Risk)
-- Recent abuse report history
-- Visual threat indicators in graph
-- Available in both CLI and web interface
-
-### 🔧 Smart Port Management
-Intelligent port conflict detection and resolution:
-
-- Automatically detects when port 5001 is in use
-- Auto-increments to next available port (5001-5005)
-- Clear error messages showing which ports are occupied
-- Manual port selection via `--port` flag
-
-### 📚 Comprehensive Documentation
-1,819 lines of developer documentation added:
-
-- **Architecture Guide** - Complete system design and technical details
-- **Feature Planning** - Roadmap, priorities, and backlog
-- **Development Guide** - Coding standards, workflows, best practices
-- **Contributing Guide** - Professional contribution guidelines
-
-## 🚀 Getting Started
-
-### Quick Start - Web Interface
-
-```bash
-git clone https://github.com/fr4nc1stein/osint-framework.git
-cd osint-framework
-source bin/activate
-pip install -r requirements.txt
-./start_web.sh
-```
-
-Then open http://localhost:5001 in your browser!
-
-### CLI with Web Server
-
-```bash
-./osif  # Web server starts automatically in background
-```
-
-### CLI Only
-
-```bash
-./osif --no-web
-```
-
-## 📦 What's New
-
-### Investigation Capabilities
-
-**Domain Investigation:**
-- Email discovery via Tomba
-- DNS records (A, MX)
-- Subdomain enumeration via Certificate Transparency (crt.sh)
-- Automatic IP resolution for discovered hosts
-
-**IP Investigation:**
-- Geolocation and ISP information (ip-api.com)
-- Reputation checking (AbuseIPDB)
-- Port scanning (Shodan)
-- Hostname discovery
-- Threat level indicators
-
-**Email Investigation:**
-- Domain extraction and linking
-- Prepared for Have I Been Pwned integration
-
-**Bitcoin Investigation:**
-- Wallet balance checking
-- Transaction history via blockchain.info
-
-### Technical Improvements
-
-- **Flask REST API** with CORS support
-- **vis.js** for interactive graph rendering
-- **Background server management** in CLI
-- **Enhanced error handling** and validation
-- **Modern responsive UI** design
-
-## 📊 By the Numbers
-
-- **5,548+ lines** of new code and documentation
-- **19 new files** added
-- **2,543 lines** of documentation
-- **3,005+ lines** of code
-- **4 comprehensive** developer guides
-
-## 🔗 New Integrations
-
-- **AbuseIPDB** - IP reputation and threat intelligence
-- **crt.sh** - Certificate Transparency for subdomain discovery
-- **ip-api.com** - IP geolocation services
-- **Enhanced Tomba** - Email discovery and verification
-
-## 🛠️ Breaking Changes
-
-None! The CLI interface remains fully backward compatible. The web interface is an addition, not a replacement.
-
-## 📝 Documentation
-
-- **Main Documentation**: https://osif.laet4x.com/
-- **Web Interface Guide**: [WEB_INTERFACE_GUIDE.md](WEB_INTERFACE_GUIDE.md)
-- **Architecture**: [.agent/architecture.md](.agent/architecture.md)
-- **Development Guide**: [.agent/development-guide.md](.agent/development-guide.md)
-- **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Changelog**: [CHANGELOG.md](CHANGELOG.md)
-
-## 🔜 What's Next (v2.1.0)
-
-We're already planning the next release with exciting features:
-
-- Database persistence for investigations
-- Async API calls for 3-5x performance improvement
-- GitHub OSINT module
-- Reddit OSINT module
-- Have I Been Pwned integration
-- Enhanced authentication system
-
-See the full roadmap in [.agent/feature-planning.md](.agent/feature-planning.md)
-
-## 🙏 Contributors
-
-Special thanks to everyone who contributed to this release:
-
-- @laet4x - Core development and web interface
-- @cadeath - Contributions and testing
-- @benemohamed - Tomba integration
-- All community contributors and testers
-
-## 💬 Feedback & Support
-
-- **Issues**: [GitHub Issues](https://github.com/fr4nc1stein/osint-framework/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/fr4nc1stein/osint-framework/discussions)
-- **Documentation**: https://osif.laet4x.com/
-
-## 📄 License
-
-OSIF is licensed under AGPL v3. See [LICENSE.md](LICENSE.md) for details.
+**Release date:** 2026-07-16  
+**Branch:** `feature/v2`
 
 ---
 
-**Full Changelog**: https://github.com/fr4nc1stein/osint-framework/compare/v1.1.1...v2.0.0
+## Overview
 
-**Download**: [v2.0.0 Release](https://github.com/fr4nc1stein/osint-framework/releases/tag/v2.0.0)
+OSIF v2.0.0 is a full platform rewrite. The Metasploit-style CLI is retained. Everything else is new.
+
+The new platform is an API-first, async, containerised investigation workspace built on:
+- **FastAPI** async backend (Python 3.12, SQLAlchemy 2.0, Pydantic v2)
+- **arq + Redis** async task queue for parallel OSINT module execution
+- **PostgreSQL** with JSONB for flexible indicator metadata
+- **MinIO** S3-compatible object store for evidence files
+- **Vue 3 + Cytoscape.js** investigation workspace frontend
+- **Docker Compose** — 8-service stack, production-hardened
+
+---
+
+## What's Included
+
+### Core Platform
+
+- FastAPI app with Alembic auto-migrate on startup
+- WebSocket real-time scan progress (`/ws/scan/{scan_id}`)
+- arq worker pool for non-blocking OSINT execution
+- Redis result caching (per-module TTL) and rate limiting (token bucket)
+- Scan templates — reusable module presets
+- Export: JSON, CSV, GraphML
+- Production `docker-compose.yaml`:
+  - Resource limits per service
+  - Redis `--requirepass` auth
+  - MinIO bucket provisioned by `minio-init`
+  - Healthcheck-gated startup ordering
+  - Log rotation (json-file driver)
+  - No source volume mounts
+
+### OSINT Modules (11)
+
+| Module | Input | External API |
+|---|---|---|
+| `dns_records` | domain | — |
+| `subdomain_enum` | domain | — |
+| `whois_lookup` | domain | — |
+| `urlscan_lookup` | domain | URLScan |
+| `email_hunter` | domain | Tomba |
+| `virustotal_domain` | domain | VirusTotal |
+| `ip_geolocation` | ip | — |
+| `abuseipdb` | ip | AbuseIPDB |
+| `shodan_lookup` | ip | Shodan |
+| `email_domain` | email | — |
+| `hibp_breach` | email | HIBP |
+
+### Case & Investigation Workspace (Phase 3.1)
+
+- Case management with status, severity, priority, assignment, client, jurisdiction, tags
+- Case knowledge graph — Cytoscape.js unified view of all scan indicators
+- Hierarchical scan relationships (parent → child)
+- Case-scoped reports: Markdown, Text, HTML, PDF
+- Report snapshots — frozen at generation time
+- Investigation notes
+- Dark/light theme
+- Integration marketplace UI with provider health cards
+- AI Analyst chat (Anthropic, OpenAI, Ollama)
+- Dashboard analytics and global search
+
+### Encrypted Credentials (Phase 3.2)
+
+- Fernet-encrypted integration credentials in PostgreSQL
+- DB-first lookup with `.env` fallback for migration compatibility
+- Secrets never returned after save
+- AI settings (provider, model, base URL, temperature) stored encrypted
+- HTML + PDF report renderer via ReportLab
+
+### PI / Skip Tracing Workspace (Phase 3.4)
+
+All 8 sub-plans complete:
+
+**A — Manual entities**
+- Create persons, aliases, phones, addresses, social profiles, companies, vehicles, documents on the case graph
+- Properties stored as JSONB; entity type drives UI icon, color, and module compatibility
+
+**B — Evidence / MinIO**
+- Upload files to MinIO (`osif-evidence` bucket); SHA-256 hash; image thumbnail generation
+- Link URL/note/screenshot evidence to any node, edge, timeline event, report, or scan
+- Evidence preview, download, and thumbnail proxied through backend API (never direct MinIO URLs)
+
+**C — Timeline**
+- Case event log with 16 event types
+- Create events manually or from graph node, evidence item, or scan
+- Events with location entity appear on the Map tab
+
+**D — Map view**
+- Leaflet/Mapbox markers for location entities, address observations, IP geolocation results, sightings
+- Marker panel with jump links to Graph, Evidence, and Timeline tabs
+- Create new location nodes directly from the map
+
+**E — Geolocation editing**
+- Set/edit location from node panel or map
+- Drag manual entity markers with explicit save step
+- Normalized `case_geolocations` table for multi-observation triangulation
+- Mapbox geocoding abstraction with external-submission consent gate
+
+**F — Leads review workflow**
+- Scan-derived indicators and edges default to `needs_review`
+- Actions: promote, merge, confirm, reject, follow-up, stale
+- Bulk operations with confirmation on bulk reject
+- Rejected leads hidden from default graph and map (auditable with `include_rejected=true`)
+
+**G — Scan from node**
+- Launch enrichment scans from any manual or promoted node in the graph
+- Entity-type → OSINT module mapping with kind normalization
+- Scan results written back as reviewable leads with provenance fields:
+  `launch_source`, `source_node_type`, `source_node_id`, `source_node_label`
+
+**H — Dossier tab + PI reports**
+- Intelligence-briefing layout: subject hero, confirmed entities, verified relationships, location board, timeline highlights, evidence locker, open leads, scan provenance
+- Subject tagging: `properties.subject_profile = true` on a manual entity
+- Sensitive evidence gated behind `include_sensitive=true`
+- Dossier report type added to Markdown, HTML, and PDF renderers
+
+---
+
+## New Database Tables
+
+```
+scan_templates
+integration_credentials
+ai_settings
+case_entities
+case_relationships
+case_evidence
+case_evidence_links
+case_timeline_events
+case_timeline_links
+case_geolocations
+case_lead_reviews
+```
+
+Total tables: 21+
+
+---
+
+## New API Endpoints (selected)
+
+```
+GET/POST   /api/v1/cases/{id}/entities
+PUT/DELETE /api/v1/cases/{id}/entities/{eid}
+GET/POST   /api/v1/cases/{id}/relationships
+PUT/DELETE /api/v1/cases/{id}/relationships/{rid}
+GET/POST   /api/v1/cases/{id}/evidence
+POST       /api/v1/cases/{id}/evidence/upload
+GET        /api/v1/cases/{id}/evidence/{eid}/download
+GET        /api/v1/cases/{id}/evidence/{eid}/thumbnail
+GET/POST   /api/v1/cases/{id}/timeline
+GET        /api/v1/cases/{id}/map
+GET        /api/v1/cases/{id}/leads
+PATCH      /api/v1/cases/{id}/leads/{type}/{id}
+GET        /api/v1/cases/{id}/dossier
+GET        /api/v1/cases/{id}/graph
+GET/PUT    /api/v1/integrations/{provider}
+POST       /api/v1/integrations/{provider}/test
+GET/PUT    /api/v1/ai/settings
+POST       /api/v1/ai/test
+```
+
+Total endpoints: 60+
+
+---
+
+## Port Mapping
+
+| Service | Host port |
+|---|---|
+| Frontend | 3000 |
+| Backend API | 6000 |
+| PostgreSQL | 5434 |
+| Redis | 6381 |
+| MinIO API | 9100 |
+| MinIO Console | 9101 |
+
+---
+
+## Statistics
+
+- Docker services: 8
+- Database tables: 21+
+- API endpoints: 60+
+- OSINT modules: 11
+- Frontend views: 10+
+- Case workspace tabs: 9 (Graph, Timeline, Evidence, Leads, Map, Dossier, Scans, Notes, Reports)
+
+---
+
+## Breaking Changes from v1.5.0
+
+The Flask + vis.js web interface (`web_server.py`, port 5001) is removed. The CLI itself is unchanged.
+
+Migration path: there is no data migration from v1.5.0. Start fresh with `docker-compose up -d --build`.
+
+---
+
+## Known Limitations
+
+- No user authentication or multi-tenant access control in this release (single-team deployment assumed)
+- AI Analyst requires a separately provisioned LLM API key
+- Mapbox geocoding requires a Mapbox token; the map renders in fallback mode without one
+- PDF report generation depends on `reportlab` in the backend image
+
+---
+
+## Full Changelog
+
+See [CHANGELOG.md](../CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,175 +7,155 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0] - 2026-05-13
+## [2.0.0] - 2026-07-16
 
-### 🎉 Major Release - Web Interface & Enhanced Features
+### Major Release — Enterprise OSINT Web Workspace
 
-This is a major release introducing a completely new web-based graph visualization interface alongside the traditional CLI, transforming OSIF into a dual-interface OSINT platform.
+Complete rewrite of OSIF as a full-stack, API-first enterprise investigation platform. The Metasploit-style CLI is retained alongside the new workspace.
 
-### ✨ Added
+---
 
-#### Web Graph Visualization
-- **Interactive Graph Interface**: Maltego-style web visualization for OSINT investigations
-- **Real-time Entity Linking**: Automatic discovery and linking of related entities
-- **Multiple Entry Points**: Support for domain, IP, email, and Bitcoin address investigations
-- **Node Interaction**: Click to view details, double-click to investigate further
-- **Export Capabilities**: Export investigation graphs as JSON
-- **Modern UI**: Responsive design with vis.js graph rendering
-- **Background Server Management**: Automatic web server startup with CLI
+### Added
 
-#### Intelligence Gathering
-- **AbuseIPDB Integration**: IP reputation checking with abuse confidence scores
-  - Threat level classification (Low/Medium/High Risk)
-  - Recent abuse report history
-  - CLI module (`modules/ioc/abuseipdb.py`)
-  - Web integration with automatic threat node creation
-- **Certificate Transparency**: Subdomain discovery via crt.sh integration
-- **Enhanced Domain Investigation**: Email discovery, DNS records, subdomain enumeration
-- **IP Geolocation**: Integration with ip-api.com for location data
-- **Email Discovery**: Tomba integration for comprehensive email finding
+#### Core Platform (Phase 1–2)
+- FastAPI async backend with Alembic migrations run automatically on startup
+- PostgreSQL + SQLAlchemy 2.0 with JSONB for flexible metadata
+- arq + Redis async task queue for parallel OSINT module execution
+- WebSocket real-time scan progress (`/ws/scan/{scan_id}`)
+- Vue 3 frontend (Vite + Pinia + Vue Router + TailwindCSS)
+- Cytoscape.js Maltego-style interactive graph visualization
+- Docker Compose stack: postgres, redis, minio, minio-init, backend, worker, frontend, console
+- Production `docker-compose.yaml` with resource limits, Redis auth, healthcheck-gated startup, log rotation
 
-#### Developer Experience
-- **Comprehensive Documentation**: 1,819 lines of developer documentation
-  - `.agent/architecture.md` - Complete system architecture (503 lines)
-  - `.agent/feature-planning.md` - Roadmap and priorities (496 lines)
-  - `.agent/development-guide.md` - Coding standards and workflows (616 lines)
-  - `.agent/README.md` - Documentation overview (204 lines)
-- **Contributing Guide**: Professional 417-line contribution guidelines
-- **Improved README**: Enhanced header with badges, navigation, and structure
+#### OSINT Engine (Phase 3)
+- Auto-linker service — detects multi-module corroborations and infers transitive relationships
+- Redis result caching per module with configurable TTL
+- Per-API rate limiting backed by Redis (token bucket)
+- Scan templates — reusable module presets
+- Export formats: JSON, CSV, GraphML
 
-#### Infrastructure
-- **Smart Port Management**: Automatic port conflict detection and increment (5001-5005)
-  - Clear error messages showing which ports are in use
-  - Auto-increment to next available port
-  - Manual port selection via `--port` flag
-- **Web Server**: Flask-based REST API with CORS support
-- **Quick Start Script**: `start_web.sh` for easy web interface launch
+#### Case & Investigation Workspace (Phase 3.1)
+- Case management — create, edit, status/severity/assignment workflow
+- Case knowledge graph — unified view merging all scan indicators
+- Hierarchical scan relationships (parent → child scans)
+- Case-scoped reports — markdown, text, HTML, and PDF (ReportLab)
+- Report snapshots — frozen at generation time
+- Investigation notes (CRUD)
+- Dark/light theme with CSS variable design system
+- Integration marketplace UI
+- AI Analyst chat interface (Anthropic, OpenAI, Ollama)
+- Dashboard analytics and global search
 
-### 🔧 Changed
+#### Encrypted Credentials (Phase 3.2)
+- Encrypted integration credentials stored in PostgreSQL (Fernet via `APP_ENCRYPTION_KEY`)
+- DB-first credential lookup with `.env` fallback for migration compatibility
+- Integration test/save/delete API — secrets never returned after save
+- Configurable AI settings (provider, model, base URL, temperature) stored encrypted in DB
+- First-run setup banner with environment import
+- HTML + PDF report renderer via ReportLab
 
-- **README.md**: Complete header redesign with centered layout, additional badges, and navigation
-- **Module System**: Enhanced with better error handling and API key validation
-- **CLI Interface**: Now includes background web server management
-- **Configuration**: Enhanced `.env.example` with AbuseIPDB and additional API keys
+#### PI / Skip Tracing Workspace (Phase 3.4)
+- **Manual entities** — create persons, aliases, phones, addresses, social profiles, companies, vehicles, documents directly on the case graph
+- **Manual relationships** — connect any two graph nodes (manual ↔ manual, manual ↔ scan indicator)
+- **Case knowledge graph merge** — scan indicators + manual entities + manual relationships in one unified graph with `graph_node_type` discriminator
+- **Evidence attachments** — upload files to MinIO, link URL/note/screenshot evidence to any node, edge, timeline event, report, or scan; SHA-256 hashing; image thumbnail generation
+- **Timeline** — case event log with manual creation and creation from node/evidence/scan; distinct icons per event type
+- **Map view** — Leaflet/Mapbox markers for location entities, address observations, IP geolocation results, and timeline sightings; marker filtering; graph/evidence/timeline jump links
+- **Geolocation editing** — set/edit location from node panel or map; drag manual markers with explicit save; normalized `case_geolocations` table for multi-observation triangulation; Mapbox geocoding abstraction with external-submission consent gate
+- **Leads review workflow** — scan-derived indicators and edges default to `needs_review`; promote, merge, confirm, reject, follow-up, or stale actions; bulk operations; rejected leads hidden from default graph and map
+- **Scan from node** — launch enrichment scans directly from any manual or promoted node; entity-type → module mapping with kind normalization; scan results written back as reviewable leads with provenance fields
+- **Dossier tab** — intelligence-briefing layout: subject hero, confirmed entities, verified relationships, location board, timeline highlights, evidence locker, open leads, scan provenance; sensitive evidence gated behind `include_sensitive=true`
+- **PI reports** — dossier report type added to Markdown, HTML, and PDF renderers; includes subject profile, verified relationships, locations, timeline, evidence index, open leads, scan provenance
 
-### 📦 Dependencies
+#### New Database Tables
+- `scan_templates`
+- `integration_credentials`
+- `ai_settings`
+- `case_entities`
+- `case_relationships`
+- `case_evidence`
+- `case_evidence_links`
+- `case_timeline_events`
+- `case_timeline_links`
+- `case_geolocations`
+- `case_lead_reviews`
 
-#### New Dependencies
-- `flask>=2.3.0` - Web framework
-- `flask-cors>=4.0.0` - CORS support
-- `requests>=2.31.0` - HTTP client (version bump)
-
-### 🗂️ File Structure
-
-#### New Files
-- `web_server.py` - Flask-based graph visualization server (505 lines)
-- `static/js/graph.js` - Interactive graph rendering (782 lines)
-- `static/js/app.js` - Frontend application logic (558 lines)
-- `static/css/style.css` - Modern UI styling (387 lines)
-- `templates/index.html` - Main web interface (105 lines)
-- `modules/ioc/abuseipdb.py` - AbuseIPDB CLI module (107 lines)
-- `WEB_INTERFACE_GUIDE.md` - Comprehensive web UI guide (307 lines)
-- `start_web.sh` - Quick start script (53 lines)
-- `CHANGELOG.md` - This file
-- `.agent/` directory - Developer documentation (4 files)
-- `screenshots/web_graph.png` - Web interface screenshot
-
-### 📊 Statistics
-
-- **Total Lines Added**: 5,548+
-- **New Files**: 19
-- **Documentation**: 2,543 lines
-- **Code**: 3,005+ lines
-
-### 🔗 API Integrations
-
-#### New Integrations
-- AbuseIPDB (IP reputation)
-- crt.sh (Certificate Transparency)
-- ip-api.com (IP geolocation)
-
-#### Enhanced Integrations
-- Tomba (email discovery)
-- DNS resolution (A, MX records)
-- Blockchain.info (Bitcoin data)
-
-### 🎯 Investigation Capabilities
-
-#### Domain Investigation
-- Email discovery (Tomba)
-- DNS records (A, MX)
-- Subdomain enumeration (Certificate Transparency)
-- Automatic IP resolution for discovered hosts
-
-#### IP Investigation
-- Geolocation and ISP information
-- Reputation checking (AbuseIPDB)
-- Port scanning (Shodan)
-- Hostname discovery
-- Threat level indicators
-
-#### Email Investigation
-- Domain extraction and linking
-- Breach checking preparation (HIBP ready)
-
-#### Bitcoin Investigation
-- Wallet balance checking
-- Transaction history
-
-### 🚀 Usage
-
-#### Web Interface
-```bash
-./start_web.sh
-# or
-python3 web_server.py
-# Then open http://localhost:5001
+#### New API Endpoints (selected)
+```
+GET/POST   /api/v1/cases/{id}/entities
+PUT/DELETE /api/v1/cases/{id}/entities/{eid}
+GET/POST   /api/v1/cases/{id}/relationships
+PUT/DELETE /api/v1/cases/{id}/relationships/{rid}
+GET/POST   /api/v1/cases/{id}/evidence
+POST       /api/v1/cases/{id}/evidence/upload
+GET        /api/v1/cases/{id}/evidence/{eid}/download
+GET        /api/v1/cases/{id}/evidence/{eid}/thumbnail
+GET/POST   /api/v1/cases/{id}/timeline
+GET        /api/v1/cases/{id}/map
+GET        /api/v1/cases/{id}/leads
+PATCH      /api/v1/cases/{id}/leads/{type}/{id}
+GET        /api/v1/cases/{id}/dossier
+GET        /api/v1/cases/{id}/graph
+GET/PUT    /api/v1/integrations/{provider}
+POST       /api/v1/integrations/{provider}/test
+GET/PUT    /api/v1/ai/settings
+POST       /api/v1/ai/test
 ```
 
-#### CLI with Web Server
-```bash
-./osif  # Web server starts automatically
-```
+---
 
-#### CLI without Web Server
-```bash
-./osif --no-web
-```
+### OSINT Modules (11)
 
-### 📝 Documentation
+| Module | Category | API Key |
+|---|---|---|
+| `dns_records` | domain | — |
+| `subdomain_enum` | domain | — |
+| `whois_lookup` | domain | — |
+| `urlscan_lookup` | domain | — |
+| `email_hunter` | domain | Tomba |
+| `virustotal_domain` | domain | VirusTotal |
+| `ip_geolocation` | ip | — |
+| `abuseipdb` | ip | AbuseIPDB |
+| `shodan_lookup` | ip | Shodan |
+| `email_domain` | email | — |
+| `hibp_breach` | email | — |
 
-- Full documentation: https://osif.laet4x.com/
-- Web Interface Guide: `WEB_INTERFACE_GUIDE.md`
-- Architecture: `.agent/architecture.md`
-- Development Guide: `.agent/development-guide.md`
-- Contributing: `CONTRIBUTING.md`
+---
 
-### 🙏 Contributors
+### Statistics
+- **Branch**: `feature/v2`
+- **Docker services**: 8
+- **Database tables**: 21+
+- **API endpoints**: 60+
+- **OSINT modules**: 11
+- **Frontend views**: 10+
+- **Case workspace tabs**: Graph, Timeline, Evidence, Leads, Map, Dossier, Scans, Notes, Reports
 
-Special thanks to all contributors who made this release possible:
-- @laet4x - Core development
-- @cadeath - Contributions
-- @benemohamed - Tomba integration
-- Community contributors
+---
 
-### 🔜 What's Next (v2.1.0)
+## [1.5.0] - 2026-05-13
 
-Planned features for the next release:
-- Database persistence for investigations
-- Async API calls for better performance
-- GitHub OSINT module
-- Reddit OSINT module
-- Have I Been Pwned integration
-- Enhanced authentication system
+### Web Graph Visualization — v1 Addition
+
+Added interactive web interface to the original CLI tool.
+
+### Added
+- Interactive graph interface (Flask + vis.js)
+- AbuseIPDB IP reputation integration
+- Subdomain discovery via Certificate Transparency (crt.sh)
+- Smart port conflict detection (5001–5005)
+- AbuseIPDB CLI module (`modules/ioc/abuseipdb.py`)
+- Web server (`web_server.py`) — Flask REST API with CORS
+- Quick start script (`start_web.sh`)
+- Developer documentation (`.agent/` — 1,819 lines)
+- Contributing guide (`CONTRIBUTING.md`)
 
 ---
 
 ## [1.1.1] - Previous Release
 
 ### Changed
-- Various bug fixes and improvements
-- Module enhancements
+- Various bug fixes and module improvements
 
 ---
 
@@ -197,7 +177,8 @@ Planned features for the next release:
 
 ---
 
-[2.0.0]: https://github.com/fr4nc1stein/osint-framework/compare/v1.1.1...v2.0.0
+[2.0.0]: https://github.com/fr4nc1stein/osint-framework/compare/v1.5.0...v2.0.0
+[1.5.0]: https://github.com/fr4nc1stein/osint-framework/compare/v1.1.1...v1.5.0
 [1.1.1]: https://github.com/fr4nc1stein/osint-framework/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/fr4nc1stein/osint-framework/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/fr4nc1stein/osint-framework/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,30 +63,65 @@ We actively welcome your pull requests:
 
 ### Prerequisites
 
-- Python 3.12 or higher
+- Docker and Docker Compose
+- Node.js 20+ (for frontend-only development)
+- Python 3.12+ (for backend-only development)
 - Git
-- Virtual environment support
 
-### Setup Steps
+### Full Stack (Recommended)
 
 ```bash
 # 1. Fork and clone the repository
 git clone https://github.com/YOUR_USERNAME/osint-framework.git
 cd osint-framework
+git checkout feature/v2
 
-# 2. Activate virtual environment
-source bin/activate
+# 2. Configure environment
+cp backend/.env.example .env
+# Edit .env and set POSTGRES_PASSWORD, REDIS_PASSWORD, MINIO_ROOT_USER, MINIO_ROOT_PASSWORD
 
-# 3. Install dependencies
+# 3. Start the full stack (migrations run automatically)
+docker-compose -f docker-compose.dev.yml up -d --build
+
+# 4. Open the UI
+open http://localhost:3000
+# API docs: http://localhost:6000/api/docs
+```
+
+### Backend-Only (Local)
+
+```bash
+cd backend
 pip install -r requirements.txt
-
-# 4. Configure environment
 cp .env.example .env
-# Edit .env with your API keys
 
-# 5. Test the installation
-./osif --help
-python3 web_server.py
+# Start supporting services
+docker-compose -f ../docker-compose.dev.yml up -d postgres redis minio minio-init
+
+# Run migrations
+alembic upgrade head
+
+# Start API server with reload
+uvicorn app.main:app --reload --host 0.0.0.0 --port 6000
+```
+
+### Frontend-Only (Local)
+
+```bash
+cd frontend
+npm install
+# Ensure backend is running at localhost:6000
+npm run dev   # http://localhost:5173
+```
+
+### CLI Console
+
+```bash
+# Attach to the running console container
+docker exec -it osif_console ./osif
+
+# Or build and run standalone
+docker-compose -f docker-compose.dev.yml run --rm console ./osif
 ```
 
 ### Developer Documentation
@@ -212,123 +247,92 @@ docs: update API documentation for domain investigation
 
 ## 🔧 Module Development
 
-### Creating a New Module
+### Creating a New OSINT Module (v2)
 
-Modules are organized by category in the `modules/` directory:
+Backend OSINT modules live in `backend/app/modules/<category>/`.
 
-```
-modules/
-├── attack-surface/
-├── blockchain/
-├── email/
-├── geolocation/
-├── host_enum/
-├── ioc/
-├── mobile/
-├── source-code/
-└── web_enum/
-```
+Categories: `domain`, `ip`, `email`, `username`, `phone`, `bitcoin`
 
 ### Module Template
 
 ```python
-from sploitkit import *
-from dotenv import load_dotenv
-from terminaltables import SingleTable
-import os
-import requests
+from app.modules.base import BaseOSINTModule
+from app.modules.registry import register_module
 
-class YourModuleName(Module):
-    """Brief description of what this module does
-    
-    Author:  your-name
-    Version: 1.0
-    """
-    load_dotenv()
-    API_KEY = os.getenv('YOUR_API_KEY')
+@register_module
+class YourModule(BaseOSINTModule):
+    MODULE_ID = "your_module"
+    DISPLAY_NAME = "Your Module"
+    DESCRIPTION = "What this module does"
+    CATEGORY = "domain"          # or ip, email, username, phone, bitcoin
+    ACCEPTS = ["domain"]         # seed_kind values this module handles
 
-    config = Config({
-        Option(
-            'TARGET',
-            "Description of target parameter",
-            True,  # Required
-        ): str("default-value"),
-    })    
+    async def execute(self, target: str, kind: str, **kwargs) -> list[dict]:
+        api_key = await self.get_credential("YOUR_API_KEY_NAME")
+        if not api_key:
+            return []
 
-    def run(self):
-        """Main execution logic"""
-        if not self.API_KEY:
-            self.logger.error("API key not configured")
-            return
-
-        target = self.config.option('TARGET').value
-        
-        try:
-            results = self.investigate(target)
-            self.display_results(results)
-        except Exception as e:
-            self.logger.error(f"Error: {e}")
-    
-    def investigate(self, target: str) -> dict:
-        """Perform the investigation"""
-        # Implementation
-        pass
-    
-    def display_results(self, results: dict):
-        """Display results in formatted table"""
-        table_data = [
-            ("Field", "Value"),
-            ("Target", results.get("target")),
-        ]
-        table = SingleTable(table_data, "Results")
-        print("\n" + table.table)
+        results = []
+        # ... call external API, build indicator dicts ...
+        return results
 ```
+
+The module auto-registers on backend startup. Results are written to `scan_results` and appear in the case graph.
+
+### Credential Access
+
+Integration credentials are stored encrypted in PostgreSQL. Use `self.get_credential("PROVIDER_NAME")` — it falls back to the `.env` file if no DB record exists.
 
 ### Module Checklist
 
-- [ ] Inherits from `Module` class
-- [ ] Has descriptive docstring
-- [ ] Validates API keys (if required)
-- [ ] Handles errors gracefully
-- [ ] Displays results in formatted table
-- [ ] Follows naming conventions
-- [ ] Added to appropriate category folder
+- [ ] Inherits from `BaseOSINTModule`
+- [ ] `MODULE_ID` is unique and snake_case
+- [ ] `ACCEPTS` list is accurate
+- [ ] Returns `[]` (not raises) when credential is missing
+- [ ] Returns `[]` (not raises) on API error
+- [ ] Result dicts follow the indicator schema (`type`, `value`, `metadata`)
+- [ ] Registered in the correct category folder
 
 ---
 
 ## 🧪 Testing
 
-### Manual Testing
+### Backend Tests
 
 ```bash
-# Test CLI module
-./osif
-use category/module_name
-show options
-set TARGET value
-run
+cd backend
 
-# Test web server
-python3 web_server.py
-# Open http://localhost:5001 and test
+# Run all tests
+pytest
+
+# With coverage
+pytest --cov=app tests/
+
+# Specific file
+pytest tests/unit/test_modules.py
 ```
 
-### Writing Tests (Future)
+### Manual API Testing
 
-When the test framework is implemented:
+```bash
+# Health check
+curl http://localhost:6000/health
 
-```python
-# tests/test_your_module.py
-import pytest
-from modules.category.your_module import YourModuleName
+# List modules
+curl http://localhost:6000/api/v1/modules | jq '[.[] | .module_id]'
 
-def test_module_loads():
-    module = YourModuleName()
-    assert module is not None
+# Create a case and run a scan
+curl -X POST http://localhost:6000/api/v1/cases \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Test", "description": "dev test"}'
+```
 
-def test_module_requires_api_key():
-    # Test implementation
-    pass
+### Frontend Dev
+
+```bash
+cd frontend
+npm run lint
+npm run type-check
 ```
 
 ---

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,134 +1,145 @@
-# OSIF v2.0 - Quick Start Guide
+# OSIF v2.0 — Quick Start
 
-## 🚀 One-Command Setup
-
-Everything is automated! Just run:
+## One-Command Setup
 
 ```bash
-cd /Users/alfrancis/Desktop/Projects/osint-framework
-
-# Start all services (migrations run automatically)
-docker-compose -f docker-compose.dev.yml up -d
+git clone https://github.com/fr4nc1stein/osint-framework osif
+cd osif
+git checkout feature/v2
+cp backend/.env.example .env
+docker-compose -f docker-compose.dev.yml up -d --build
 ```
 
-That's it! The system will:
-- ✅ Start PostgreSQL and Redis
-- ✅ Wait for databases to be ready
-- ✅ Run database migrations automatically
-- ✅ Start the FastAPI server on port **6000**
+The stack starts automatically:
+- Waits for PostgreSQL and Redis to be healthy
+- Provisions the MinIO `osif-evidence` bucket
+- Runs all Alembic migrations
+- Starts backend API on port 6000
+- Serves the frontend on port 3000
 
-## 📊 View Logs
+## Verify All Services
 
 ```bash
-# Watch initialization process
-docker-compose -f docker-compose.dev.yml logs -f backend
-
-# You should see:
-# 🚀 OSIF v2.0 Backend - Starting initialization...
-# ⏳ Waiting for PostgreSQL...
-# ✅ PostgreSQL is ready!
-# ⏳ Waiting for Redis...
-# ✅ Redis is ready!
-# 🔄 Running database migrations...
-# ✅ Migrations complete!
-# 🎯 Starting application...
+docker-compose -f docker-compose.dev.yml ps
 ```
 
-## 🧪 Test the API
+```
+NAME              STATUS         PORTS
+osif_postgres     Up (healthy)   0.0.0.0:5434->5432/tcp
+osif_redis        Up (healthy)   0.0.0.0:6381->6379/tcp
+osif_minio        Up (healthy)   0.0.0.0:9100->9000/tcp, 0.0.0.0:9101->9001/tcp
+osif_minio_init   Exited (0)
+osif_backend      Up             0.0.0.0:6000->6000/tcp
+osif_worker       Up
+osif_frontend     Up             0.0.0.0:3000->80/tcp
+osif_console      Up
+```
+
+## Open the UI
+
+| Interface | URL |
+|---|---|
+| Investigation Dashboard | http://localhost:3000 |
+| API Docs (Swagger) | http://localhost:6000/api/docs |
+| MinIO Console | http://localhost:9101 |
+
+## Case Workspace Tabs
+
+Once you open a case at http://localhost:3000/cases, you get:
+
+| Tab | What it does |
+|---|---|
+| **Graph** | Interactive Cytoscape.js knowledge graph — scan indicators + manual entities + relationships |
+| **Timeline** | Chronological event log linked to entities, evidence, and scans |
+| **Evidence** | File upload library backed by MinIO — attach screenshots, PDFs, images to any node |
+| **Leads** | Review queue for scan-derived findings — promote, reject, or merge into confirmed entities |
+| **Map** | Location markers for address/location entities, IP geolocation results, and sightings |
+| **Dossier** | Subject intelligence briefing — confirmed entities, relationships, locations, open leads |
+| **Scans** | Hierarchical scan list — parent/child relationships, provenance badges |
+| **Notes** | Investigation notes |
+| **Reports** | Generate and download Markdown, HTML, or PDF reports including PI dossier format |
+
+## Quick API Test
 
 ```bash
 # Health check
 curl http://localhost:6000/health
 
-# List available OSINT modules
-curl http://localhost:6000/api/v1/modules
+# List OSINT modules
+curl http://localhost:6000/api/v1/modules | jq '[.[] | .module_id]'
 
-# Create a test case
+# Create a case
 curl -X POST http://localhost:6000/api/v1/cases \
   -H "Content-Type: application/json" \
-  -d '{
-    "title": "My First Investigation",
-    "description": "Testing OSIF v2.0",
-    "priority": "high"
-  }'
+  -d '{"title": "My First Investigation", "description": "Testing OSIF v2.0", "priority": "high"}'
+
+# Launch a scan
+curl -X POST http://localhost:6000/api/v1/scans \
+  -H "Content-Type: application/json" \
+  -d '{"seed_value": "example.com", "seed_kind": "domain", "modules": ["dns_records", "whois_lookup"]}'
 ```
 
-## 📖 API Documentation
-
-Open in your browser:
-- **Swagger UI**: http://localhost:6000/api/docs
-- **ReDoc**: http://localhost:6000/api/redoc
-
-## 🛑 Stop Services
+## CLI Console
 
 ```bash
+docker exec -it osif_console ./osif
+```
+
+## View Logs
+
+```bash
+# All services
+docker-compose -f docker-compose.dev.yml logs -f
+
+# Backend + worker only
+docker-compose -f docker-compose.dev.yml logs -f backend worker
+```
+
+## Stop
+
+```bash
+# Keep data volumes
 docker-compose -f docker-compose.dev.yml down
-```
 
-## 🔧 Rebuild After Code Changes
-
-```bash
-# Rebuild and restart
-docker-compose -f docker-compose.dev.yml up -d --build
-```
-
-## 📝 Environment Variables
-
-To configure API keys:
-
-```bash
-# Copy example file
-cp backend/.env.example backend/.env
-
-# Edit with your API keys
-nano backend/.env
-```
-
-Then restart:
-```bash
-docker-compose -f docker-compose.dev.yml restart backend
-```
-
-## 🐛 Troubleshooting
-
-### Port 6000 already in use?
-
-```bash
-# Check what's using the port
-lsof -i :6000
-
-# Kill the process or change the port in docker-compose.dev.yml
-```
-
-### Database connection issues?
-
-```bash
-# Check PostgreSQL is running
-docker-compose -f docker-compose.dev.yml ps postgres
-
-# View PostgreSQL logs
-docker-compose -f docker-compose.dev.yml logs postgres
-```
-
-### Reset everything?
-
-```bash
-# Stop and remove all data
+# Wipe everything (fresh start)
 docker-compose -f docker-compose.dev.yml down -v
-
-# Start fresh
-docker-compose -f docker-compose.dev.yml up -d
 ```
 
-## 📚 Next Steps
+## Rebuild After Changes
 
-1. **Explore API**: http://localhost:6000/api/docs
-2. **Read Backend Docs**: `backend/README.md`
-3. **Check Architecture**: `docs/architecture.md`
-4. **View Spec**: `docs/spec.md`
+```bash
+docker-compose -f docker-compose.dev.yml up -d --build
+
+# Single service
+docker-compose -f docker-compose.dev.yml up -d --build backend
+```
+
+## Troubleshooting
+
+**Port already in use:**
+```bash
+lsof -i :6000   # or :3000, :5434, :6381, :9100
+```
+Change host-side ports in `docker-compose.dev.yml` to resolve conflicts.
+
+**Database not ready:**
+```bash
+docker-compose -f docker-compose.dev.yml logs postgres
+docker-compose -f docker-compose.dev.yml exec postgres psql -U osif -c "\dt"
+```
+
+**Run migration manually:**
+```bash
+docker-compose -f docker-compose.dev.yml exec backend alembic upgrade head
+```
+
+**Reset MinIO bucket:**
+```bash
+docker-compose -f docker-compose.dev.yml run --rm minio-init
+```
 
 ---
 
-**Port:** 6000  
-**Auto-migrations:** ✅ Enabled  
-**Hot-reload:** ✅ Enabled (development mode)
+**Backend API:** http://localhost:6000  
+**Frontend:** http://localhost:3000  
+**Docs:** http://localhost:6000/api/docs

--- a/WEB_INTERFACE_GUIDE.md
+++ b/WEB_INTERFACE_GUIDE.md
@@ -1,307 +1,306 @@
-# OSIF Web Interface - User Guide
+# OSIF v2.0 — Web Interface Guide
 
-## 🌐 Overview
+## Overview
 
-The OSIF Web Interface provides a **Maltego-style graph visualization** for OSINT investigations. It allows you to:
+OSIF v2.0 ships a full enterprise investigation workspace accessible at **http://localhost:3000**.
 
-- Visualize relationships between domains, IPs, emails, and other entities
-- Interactively explore OSINT data through an intuitive graph interface
-- Chain investigations by double-clicking nodes to expand them
-- Export investigation graphs as JSON
+The interface is built on Vue 3 with Cytoscape.js graph visualization, a MinIO-backed evidence library, and a real-time scan engine powered by WebSocket events.
 
-## 🚀 Quick Start
+---
 
-### 1. Install Dependencies
+## Getting Started
 
 ```bash
-pip install -r requirements.txt
+docker-compose -f docker-compose.dev.yml up -d --build
 ```
 
-### 2. Configure API Keys
+Open http://localhost:3000 in your browser.
 
-Make sure your `.env` file contains the necessary API keys:
+---
 
-```env
-HUNTER_API_KEY="your_hunter_key"
-SHODAN_API_KEY="your_shodan_key"
-VT_API="your_virustotal_key"
-TOMBA_API_KEY="your_tomba_key"
-TOMBA_SECRET_KEY="your_tomba_secret"
+## Navigation
+
+The sidebar provides access to:
+
+| Item | Route | Purpose |
+|---|---|---|
+| Dashboard | `/` | Stats overview, recent cases and scans |
+| Cases | `/cases` | Investigation case management |
+| Scans | `/scans` | All scans across cases |
+| Reports | `/reports` | Generated case reports |
+| Integrations | `/integrations` | API key management and provider health |
+| AI Analyst | `/ai` | Chat with an LLM over case context |
+| AI Settings | `/settings/ai` | Configure provider, model, and API key |
+
+---
+
+## Dashboard
+
+Shows live metrics:
+- Active cases count
+- Scans by status (queued / running / completed / error)
+- Total indicators discovered
+- Recent activity feed
+
+---
+
+## Cases
+
+### Case List (`/cases`)
+
+Displays all investigation cases in a card grid. Filter by status, priority, and date.
+
+**Create a case:** click **New Case** and fill in title, description, priority/severity, case type, assigned analyst, client, jurisdiction, and tags.
+
+### Case Workspace (`/cases/:id`)
+
+The case workspace is the primary investigation surface. It has a fixed header with quick status and severity controls and a tab bar.
+
+---
+
+## Case Workspace Tabs
+
+### Graph
+
+Interactive Cytoscape.js knowledge graph showing:
+- **Scan indicators** — nodes discovered by automated OSINT modules (blue/green/amber — by node type)
+- **Manual entities** — nodes added by analysts (persons, phones, addresses, social profiles, companies, vehicles, documents)
+- **Manual relationships** — edges drawn between any two nodes
+- **Scan edges** — relationships discovered by modules
+
+**Toolbar actions:**
+- **Add Node** — create a manual entity
+- **Add Connected Node** — create a node already linked to a selected node
+- **Connect Nodes** — draw a relationship between two existing nodes
+- **Scan from node** — launch an OSINT scan directly from a selected node (maps entity type to compatible modules)
+
+**Node panel (right sidebar):**
+Clicking any node opens a slide-in panel showing:
+- Node type, value, confidence bar
+- Metadata key/value pairs
+- Linked evidence with preview/download
+- Connected edges with linked node labels and source module
+- **Scan from this node** — opens the scan modal pre-filled
+- **Add timeline event** — log an analyst observation
+
+**Node colors by type:**
+
+| Type | Color |
+|---|---|
+| domain | Blue |
+| ip | Emerald |
+| email | Amber |
+| breach / threat | Red |
+| subdomain | Sky |
+| hostname | Violet |
+| nameserver | Amber |
+| person / alias | Indigo / Purple |
+| address | Rose |
+| social profile | Yellow |
+| company / org | Slate |
+| vehicle | Emerald |
+| document | Slate |
+| port / service | Cyan |
+| url / profile_url | Yellow |
+
+---
+
+### Timeline
+
+Chronological event log for the case.
+
+**Event types:** sighting, address observed, phone observed, email observed, account created, profile updated, domain registered, breach observed, scan run, report generated, note added, contact attempt, employment observed, travel or movement, legal event, custom.
+
+**Create an event:** click **+ Event** or use **Add timeline event** from any graph node.
+
+Each event can link to entities, evidence, scans, and relationships. Events with a location entity appear on the Map tab.
+
+---
+
+### Evidence
+
+Evidence library backed by MinIO S3-compatible storage.
+
+**Supported evidence types:** note, URL, screenshot, image, document, PDF, text, scan result, API response, map location, analyst observation.
+
+**Attach evidence:**
+- Upload a file (image, PDF, document) — SHA-256 hashed, thumbnail generated for images
+- Add a URL source with title and description
+- Add a freetext note
+
+**Linking:** evidence items can attach to entities, relationships, timeline events, reports, and scans. One evidence item can link to multiple objects.
+
+**Security:** the frontend never communicates with MinIO directly. All file access goes through backend API routes:
+```
+GET /api/v1/cases/{id}/evidence/{eid}/download
+GET /api/v1/cases/{id}/evidence/{eid}/thumbnail
+GET /api/v1/cases/{id}/evidence/{eid}/preview
 ```
 
-### 3. Start the Web Server
+---
 
+### Leads
+
+Review queue for scan-derived findings before they become confirmed facts.
+
+Scan-derived indicators and edges default to `needs_review` status. The Leads tab lets analysts review them before they appear as confirmed objects in the graph and dossier.
+
+**Lead statuses:** needs_review, confirmed, follow_up, stale, rejected.
+
+**Actions per lead:**
+- **Confirm** — mark as confirmed; appears in graph and dossier
+- **Reject** — hidden from default graph and map (still visible with `include_rejected=true` for audit)
+- **Follow up** — flag for later review
+- **Promote** — convert a scan indicator into a manual case entity
+- **Merge** — combine a scan indicator into an existing manual entity
+
+**Bulk actions:** select multiple leads → bulk confirm, follow-up, stale, or reject (reject asks for confirmation).
+
+---
+
+### Map
+
+Location map for address/location entities, IP geolocation results, and timeline sightings.
+
+**What appears:**
+- Manual entities with `latitude`/`longitude` in properties
+- IP geolocation evidence (marked as approximate)
+- Timeline events linked to a location entity
+- Case geolocation observations
+
+**Marker panel:** click any marker to see linked entities, evidence, and timeline events with jump links to those tabs.
+
+**Editing:**
+- Manual entity markers can be dragged to reposition; dragging opens the location editor for an explicit save step
+- Click **Map** on an unmapped entity in the sidebar to place it on the map
+- Create new person, location, or office nodes directly from the map with coordinates prefilled
+
+**Filters:** source type, entity type, confidence, verification status.
+
+---
+
+### Dossier
+
+Intelligence briefing view for the primary case subject.
+
+Sections:
+- **Subject hero** — name, role, status, case priority chips
+- **Signal metrics** — confirmed entity count, verified relationship count, location count, open lead count
+- **Subject profile** — custom properties from the entity tagged as the primary subject
+- **Confirmed entities** — grouped by type: people, contact, digital, location, organization, assets
+- **Verified relationships** — relationship matrix between confirmed entities
+- **Location board** — all mapped locations with precision and confidence badges
+- **Timeline highlights** — key confirmed timeline events
+- **Evidence locker** — linked evidence summaries (sensitive evidence gated)
+- **Open leads** — unresolved review queue items
+- **Scan provenance** — scan origins contributing to the dossier
+
+**Subject tagging:** set `properties.subject_profile = true` on a manual entity to make it the dossier primary subject.
+
+**Sensitive evidence:** controlled by the toggle in the dossier header. Sensitive types (legal documents, identity documents, private messages, financial records) are hidden by default.
+
+---
+
+### Scans
+
+Hierarchical list of scans in this case.
+
+- Parent → child indentation
+- Status badges (queued / running / completed / error)
+- Module list per scan
+- Progress bar for running scans
+- Launch source badge for node-initiated scans (shows source node label)
+- **Create child scan** — launch a new scan under any existing scan
+
+---
+
+### Notes
+
+Investigation notes with add/delete. Supports freetext content.
+
+---
+
+### Reports
+
+Generate and download case reports.
+
+**Formats:** Markdown, Text, HTML, PDF
+
+**Report types:**
+- Summary — case overview, scans, indicators, relationships, notes
+- Technical — detailed indicator and edge data
+- Timeline — chronological event summary
+- Dossier — subject profile, confirmed entities, verified relationships, locations, timeline, evidence index, open leads, scan provenance
+
+Reports are **frozen at generation time** (snapshot stored in PostgreSQL). Downloading a report later always returns the same content.
+
+**Download:** click the download icon on any report card. HTML and PDF open inline for preview.
+
+---
+
+## Integration Management (`/integrations`)
+
+Provider cards showing:
+- Configured / not configured status
+- Last test result
+- Enable/disable toggle
+- **Test connection** button
+- Credential masked hint
+
+**Save a key:** click the card → enter API key → Save. The key is encrypted with Fernet before storage. It is never returned in any API response after save.
+
+**Providers:** Shodan, VirusTotal, AbuseIPDB, Tomba, Hunter, HIBP, IPinfo, AlienVault OTX, Censys, URLScan, Mapbox.
+
+---
+
+## AI Analyst (`/ai`)
+
+Chat interface connected to a configured LLM provider.
+
+**Context options:** current case, current scan, all data.
+
+**Suggested prompts:** Summarize findings, List key indicators, Suggest next investigation steps.
+
+**Configure provider at** `/settings/ai`:
+- Provider: Anthropic, OpenAI, Ollama
+- Model name
+- API key (encrypted at rest)
+- Base URL (for Ollama or OpenAI-compatible endpoints)
+- Temperature and max tokens
+- Test connection
+
+---
+
+## Theme
+
+Toggle dark/light mode from the sidebar bottom button. Theme persists in `localStorage`.
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Escape` | Close modal |
+
+---
+
+## Troubleshooting
+
+**Graph is empty after adding a manual entity:**
+Refresh the graph tab or click away and back — the graph re-fetches after any entity/relationship mutation.
+
+**Evidence upload fails:**
+Check MinIO is running: `docker-compose -f docker-compose.dev.yml ps minio`. Re-run `minio-init` if the bucket is missing:
 ```bash
-python web_server.py
+docker-compose -f docker-compose.dev.yml run --rm minio-init
 ```
 
-The server will automatically open your browser at `http://localhost:5000`
+**Map shows no markers:**
+Only entities with `latitude` and `longitude` in their `properties`, or linked geolocation observations, appear on the map. Use **Set Location** from the node panel to add coordinates.
 
-## 📊 Features
+**Dossier shows no subject:**
+Tag one manual entity with `properties.subject_profile = true` from the node panel → Edit → Custom Properties.
 
-### Investigation Tools
-
-#### 🌐 Domain Investigation
-- **Input:** Domain name (e.g., `example.com`)
-- **Discovers:**
-  - Email addresses associated with the domain
-  - DNS records and IP addresses
-  - Subdomains
-  - Technology stack (CMS, frameworks, libraries)
-
-#### 🔌 IP Address Investigation
-- **Input:** IP address (e.g., `8.8.8.8`)
-- **Discovers:**
-  - Geolocation information
-  - ISP and organization
-  - Open ports (requires Shodan API)
-  - Hostnames
-  - Associated services
-
-#### 📧 Email Investigation
-- **Input:** Email address (e.g., `user@example.com`)
-- **Discovers:**
-  - Associated domain
-  - Domain relationships
-
-#### ₿ Bitcoin Investigation
-- **Input:** Bitcoin address
-- **Discovers:**
-  - Wallet balance
-  - Total received/sent
-  - Transaction count
-
-### Graph Interaction
-
-#### Single Click
-- Click any node to view detailed information in the side panel
-- See connections, relationships, and metadata
-
-#### Double Click
-- Double-click a node to expand and investigate it further
-- Domain nodes → trigger domain investigation
-- IP nodes → trigger IP investigation
-- Email nodes → trigger email investigation
-
-#### Navigation
-- **Pan:** Click and drag the background
-- **Zoom:** Use mouse wheel
-- **Select Multiple:** Hold Ctrl/Cmd and click nodes
-
-### Graph Controls
-
-#### Clear Graph
-Removes all nodes and edges from the current investigation
-
-#### Export JSON
-Downloads the current graph as a JSON file for:
-- Backup
-- Sharing with team members
-- Import into other tools
-
-#### Fit View
-Automatically centers and scales the graph to fit the viewport
-
-## 🎨 Node Types and Colors
-
-| Node Type | Color | Icon | Description |
-|-----------|-------|------|-------------|
-| Domain | Blue | 🌐 | Domain names |
-| Email | Red | ✉️ | Email addresses |
-| IP | Green | 🔌 | IP addresses |
-| Subdomain | Purple | 🌐 | Subdomains |
-| Technology | Orange | ⚙️ | Web technologies |
-| Location | Teal | 📍 | Geographic locations |
-| ISP | Gray | 🏢 | Internet Service Providers |
-| Port | Orange | 🔗 | Network ports |
-| Bitcoin | Gold | ₿ | Bitcoin addresses |
-
-## 🔄 Investigation Workflow
-
-### Example: Domain Investigation
-
-1. **Start with a Domain**
-   ```
-   Enter: target.com
-   Click: Investigate
-   ```
-
-2. **Review Results**
-   - Domain node appears in center
-   - Connected emails, IPs, technologies appear around it
-
-3. **Expand Investigation**
-   - Double-click an IP node to investigate it
-   - New nodes appear showing location, ISP, open ports
-
-4. **Explore Email**
-   - Click an email node to see details
-   - Double-click to investigate the email
-
-5. **Export Results**
-   - Click "Export JSON" to save your investigation
-   - Share with team or document findings
-
-### Example: Multi-Level Investigation
-
-```
-Domain (example.com)
-  ├─> Emails (john@example.com, admin@example.com)
-  ├─> IPs (93.184.216.34)
-  │     ├─> Location (Los Angeles, USA)
-  │     ├─> ISP (EdgeCast Networks)
-  │     └─> Ports (80, 443, 8080)
-  ├─> Subdomains (api.example.com, mail.example.com)
-  └─> Technologies (WordPress, MySQL, Cloudflare)
-```
-
-## 🔧 Advanced Features
-
-### API Endpoints
-
-The web server exposes REST APIs for programmatic access:
-
-#### Get Graph Data
-```bash
-curl http://localhost:5000/api/graph
-```
-
-#### Investigate Domain
-```bash
-curl -X POST http://localhost:5000/api/investigate/domain \
-  -H "Content-Type: application/json" \
-  -d '{"domain": "example.com"}'
-```
-
-#### Clear Graph
-```bash
-curl -X POST http://localhost:5000/api/graph/clear
-```
-
-### Export Format
-
-Exported JSON includes:
-```json
-{
-  "graph": {
-    "nodes": [
-      {
-        "id": "domain_example.com",
-        "label": "example.com",
-        "type": "domain",
-        "data": {...},
-        "timestamp": "2026-02-02T..."
-      }
-    ],
-    "edges": [
-      {
-        "from": "domain_example.com",
-        "to": "email_john@example.com",
-        "relationship": "has_email",
-        "timestamp": "2026-02-02T..."
-      }
-    ]
-  },
-  "exported_at": "2026-02-02T...",
-  "node_count": 15,
-  "edge_count": 18
-}
-```
-
-## 🎯 Use Cases
-
-### 1. Threat Intelligence
-- Map out malicious infrastructure
-- Identify related domains and IPs
-- Track threat actor email addresses
-
-### 2. Digital Footprint Analysis
-- Discover organization's external attack surface
-- Identify exposed services and technologies
-- Map subdomain structure
-
-### 3. Investigation Support
-- Visual documentation of findings
-- Easy sharing with team members
-- Historical tracking of investigations
-
-### 4. Reconnaissance
-- Pre-engagement information gathering
-- Technology stack identification
-- Contact discovery
-
-## 🔒 Security Notes
-
-- The web server runs on `0.0.0.0:5000` by default (accessible from network)
-- For production use, consider:
-  - Adding authentication
-  - Using HTTPS
-  - Rate limiting API calls
-  - Running behind a reverse proxy
-
-## 🐛 Troubleshooting
-
-### Web Server Won't Start
-```bash
-# Check if port 5000 is already in use
-lsof -i :5000
-
-# Use a different port
-FLASK_RUN_PORT=8080 python web_server.py
-```
-
-### No Results for Investigations
-- Verify API keys in `.env` file
-- Check API rate limits
-- Ensure internet connectivity
-
-### Graph Not Loading
-- Clear browser cache
-- Check browser console for errors (F12)
-- Verify Flask server is running
-
-### Modules Not Found
-```bash
-# Reinstall dependencies
-pip install -r requirements.txt
-```
-
-## 📝 Tips & Best Practices
-
-1. **Start Small:** Begin with one entity and expand gradually
-2. **Use Double-Click:** Quickly expand investigations by double-clicking nodes
-3. **Export Often:** Save your work regularly using Export JSON
-4. **Clear When Needed:** Use Clear Graph to start fresh investigations
-5. **Check Details:** Click nodes to see full metadata in the details panel
-6. **API Keys:** More API keys = more comprehensive results
-
-## 🔄 Integration with CLI
-
-You can use both the web interface and CLI together:
-
-1. Use web interface for **visual exploration**
-2. Use CLI (`./osif`) for **detailed module execution**
-3. Use API endpoints for **automation**
-
-## 📚 Related Documentation
-
-- [README.md](../README.md) - Main project documentation
-- [CONTRIBUTING.md](../CONTRIBUTING.md) - How to contribute
-- API Documentation: Check individual modules in `/modules`
-
-## 💡 Future Enhancements
-
-Planned features:
-- [ ] Save/load investigation sessions
-- [ ] Real-time collaboration
-- [ ] More visualization layouts (hierarchical, radial)
-- [ ] Timeline view of investigations
-- [ ] Report generation (PDF/HTML)
-- [ ] Graph filtering and search
-- [ ] Custom node types and relationships
-
-## 🤝 Support
-
-For issues or questions:
-- GitHub Issues: https://github.com/fr4nc1stein/osint-framework/issues
-- Documentation: https://osif.laet4x.com/
+**Scan from node shows no modules:**
+The node type must map to a supported scan target kind (domain, ip, email, url, username, phone, bitcoin). Unsupported types (e.g. `vehicle`, `document`) cannot trigger automated scans.

--- a/backend/README.md
+++ b/backend/README.md
@@ -128,6 +128,61 @@ pytest --cov=app tests/
 pytest tests/unit/test_modules.py
 ```
 
+## Key API Endpoints
+
+```
+GET  /health                                       # liveness
+GET  /ready                                        # readiness (DB + Redis)
+
+# Cases
+GET/POST   /api/v1/cases
+GET/PUT    /api/v1/cases/{id}
+
+# Knowledge graph
+GET        /api/v1/cases/{id}/graph
+GET/POST   /api/v1/cases/{id}/entities
+PUT/DELETE /api/v1/cases/{id}/entities/{eid}
+GET/POST   /api/v1/cases/{id}/relationships
+PUT/DELETE /api/v1/cases/{id}/relationships/{rid}
+
+# Evidence
+GET/POST   /api/v1/cases/{id}/evidence
+POST       /api/v1/cases/{id}/evidence/upload
+GET        /api/v1/cases/{id}/evidence/{eid}/download
+GET        /api/v1/cases/{id}/evidence/{eid}/thumbnail
+GET        /api/v1/cases/{id}/evidence/{eid}/preview
+
+# Timeline
+GET/POST   /api/v1/cases/{id}/timeline
+PUT/DELETE /api/v1/cases/{id}/timeline/{tid}
+
+# Map + Geolocation
+GET        /api/v1/cases/{id}/map
+
+# Leads review
+GET        /api/v1/cases/{id}/leads
+PATCH      /api/v1/cases/{id}/leads/{type}/{lid}
+
+# Dossier
+GET        /api/v1/cases/{id}/dossier
+
+# Scans
+GET/POST   /api/v1/scans
+GET        /api/v1/scans/{id}
+GET        /api/v1/cases/{id}/scans
+
+# Integrations
+GET/PUT    /api/v1/integrations/{provider}
+POST       /api/v1/integrations/{provider}/test
+
+# AI
+GET/PUT    /api/v1/ai/settings
+POST       /api/v1/ai/test
+POST       /api/v1/ai/chat
+```
+
+Full interactive docs at http://localhost:6000/api/docs.
+
 ## Health Checks
 
 - `/health` - Liveness probe (always returns 200)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,96 @@
-# Vue 3 + Vite
+# OSIF v2.0 Frontend
 
-This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+Vue 3 + Vite single-page application for the OSIF enterprise investigation workspace.
 
-Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).
+## Stack
+
+- **Vue 3** with `<script setup>` Composition API
+- **Vite** — fast dev server and production build
+- **Pinia** — state management
+- **Vue Router** — client-side routing
+- **TailwindCSS** — utility-first styling with dark/light theme support
+- **Cytoscape.js** — Maltego-style interactive knowledge graph
+- **Leaflet / Mapbox GL** — case geolocation map
+- **Chart.js** — dashboard analytics
+
+## Development
+
+```bash
+# Requires the backend and supporting services to be running first
+docker-compose -f ../docker-compose.dev.yml up -d postgres redis minio minio-init backend worker
+
+# Install dependencies
+npm install
+
+# Start dev server (http://localhost:5173 with HMR)
+npm run dev
+
+# Type check
+npm run type-check
+
+# Lint
+npm run lint
+
+# Production build
+npm run build
+```
+
+The dev server proxies `/api` and `/ws` to `http://localhost:6000` via `vite.config.ts`.
+
+## Full Stack (Recommended)
+
+```bash
+docker-compose -f ../docker-compose.dev.yml up -d --build
+```
+
+Frontend served by Nginx at http://localhost:3000.
+
+## Project Structure
+
+```
+src/
+├── api/              # Typed axios client wrappers per resource
+├── assets/           # Static assets
+├── components/       # Reusable UI components
+│   ├── case/         # Case workspace tab components
+│   ├── graph/        # Cytoscape node/edge renderers, node panel
+│   ├── scan/         # Scan modal, progress, hierarchy
+│   └── ui/           # Shared: buttons, modals, badges, tables
+├── composables/      # Vue composables (useGraph, useScan, useEvidence, ...)
+├── router/           # Route definitions
+├── stores/           # Pinia stores (case, scan, ui, auth)
+├── types/            # TypeScript interfaces
+└── views/            # Page-level components
+    ├── DashboardView.vue
+    ├── CaseListView.vue
+    ├── CaseWorkspaceView.vue   # Tab host: Graph/Timeline/Evidence/Leads/Map/Dossier/Scans/Notes/Reports
+    ├── ScanListView.vue
+    ├── ReportListView.vue
+    ├── IntegrationsView.vue
+    ├── AIAnalystView.vue
+    └── AISettingsView.vue
+```
+
+## Case Workspace Tabs
+
+| Tab | Component | Description |
+|---|---|---|
+| Graph | `CaseGraphTab.vue` | Cytoscape.js knowledge graph with node panel |
+| Timeline | `CaseTimelineTab.vue` | Chronological event log |
+| Evidence | `CaseEvidenceTab.vue` | MinIO-backed file library |
+| Leads | `CaseLeadsTab.vue` | Review queue — confirm/reject/promote/merge |
+| Map | `CaseMapTab.vue` | Leaflet/Mapbox location markers |
+| Dossier | `CaseDossierTab.vue` | Subject intelligence briefing |
+| Scans | `CaseScansTab.vue` | Hierarchical scan list |
+| Notes | `CaseNotesTab.vue` | Investigation notes |
+| Reports | `CaseReportsTab.vue` | Generate Markdown / HTML / PDF reports |
+
+## Environment
+
+Copy `../.env.example` to `../.env`. The Vite dev server reads `VITE_API_BASE_URL` (defaults to `/api`).
+
+Production builds use the Nginx config to proxy API and WebSocket traffic to the backend container — no client-side base URL configuration is needed.
+
+## Theme
+
+Dark/light mode toggled from the sidebar and persisted in `localStorage`. Implemented via CSS custom properties and a `dark` class on `<html>`.


### PR DESCRIPTION
Complete documentation overhaul covering the full v2 stack:
- CHANGELOG.md: proper [2.0.0] entry for all phases 1-3.4H; old [2.0.0] (Flask/vis.js) renamed to [1.5.0]
- QUICKSTART.md: 8-service Docker stack, case workspace tabs table, port map
- WEB_INTERFACE_GUIDE.md: full Vue 3 + Cytoscape.js workspace guide (replaces v1 Flask content)
- CONTRIBUTING.md: v2 dev setup (Docker), module template updated to BaseOSINTModule (replaces sploitkit)
- backend/README.md: Phase 3.4 endpoint reference added
- frontend/README.md: real content replacing Vite placeholder
- .agent/RELEASE_NOTES_v2.0.0.md: rewritten for actual v2 enterprise platform